### PR TITLE
AnimeTask.asmdef の versionDefines に UGUIを追加

### DIFF
--- a/Assets/AnimeTask/AnimeTask.asmdef
+++ b/Assets/AnimeTask/AnimeTask.asmdef
@@ -16,6 +16,11 @@
             "name": "com.neuecc.unirx",
             "expression": "",
             "define": "ANIMETASK_UNIRX_SUPPORT"
+        },
+        {
+            "name": "com.unity.ugui",
+            "expression": "",
+            "define": "ANIMETASK_UGUI_SUPPORT"
         }
     ],
     "noEngineReferences": false

--- a/Assets/AnimeTask/Scripts/Translator/RectTransformTranslator.cs
+++ b/Assets/AnimeTask/Scripts/Translator/RectTransformTranslator.cs
@@ -1,3 +1,4 @@
+#if !UNITY_2019_1_OR_NEWER || ANIMETASK_UGUI_SUPPORT
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
@@ -60,3 +61,4 @@ namespace AnimeTask
         }
     }
 }
+#endif

--- a/Assets/AnimeTask/Scripts/Translator/RectTransformTranslator.cs
+++ b/Assets/AnimeTask/Scripts/Translator/RectTransformTranslator.cs
@@ -1,4 +1,4 @@
-#if !UNITY_2019_1_OR_NEWER || ANIMETASK_UGUI_SUPPORT
+#if ANIMETASK_UGUI_SUPPORT
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using UnityEngine;

--- a/Assets/AnimeTask/Scripts/Translator/UGuiTranslator.cs
+++ b/Assets/AnimeTask/Scripts/Translator/UGuiTranslator.cs
@@ -1,4 +1,4 @@
-#if !UNITY_2019_1_OR_NEWER || ANIMETASK_UGUI_SUPPORT
+#if ANIMETASK_UGUI_SUPPORT
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using UnityEngine;

--- a/Assets/AnimeTask/Scripts/Translator/UGuiTranslator.cs
+++ b/Assets/AnimeTask/Scripts/Translator/UGuiTranslator.cs
@@ -1,3 +1,4 @@
+#if !UNITY_2019_1_OR_NEWER || ANIMETASK_UGUI_SUPPORT
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
@@ -97,3 +98,4 @@ namespace AnimeTask
         }
     }
 }
+#endif


### PR DESCRIPTION
これから使い込ませていただこうと思っております :hugs: 

今後は UGUI or UIToolkit （2021.2 > `com.unity.ui` , 2021.2 <= `com.unity.modules.uielements`）という選択肢があり`com.unity.ugui` パッケージは削除されうる（したい需要がある）ため、 `package.json` の `dependencies` ではなく該当 `asmdef` の `versionDefines` に追加し、UGUIサポートをオプションとするように変更いたしました。

ただ、 `Sample` がUGUIに依存しているため実際は `dependencies` に追加したほうが良いかもしれません（UGUIをデバッグ用途でしか使用していない？ `Core RP Library` と同様に）。

現状ここの取り扱いに悩み、特に何も対応していないためこの状態で `com.unity.ugui` パッケージを削除すると `Sample/SampleMenu.cs` でコンパイルエラーが発生する状態となっております（方針に沿って対応させていただきます）。